### PR TITLE
Fix useless dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Build-Depends: debhelper (>= 9),
                qtquickcontrols2-5-dev,
                kirigami2-dev,
                cmake
-Standards-Version: 4.0.0
+Standards-Version: 4.1.1
 Homepage: https://github.com/kaidanim/kaidan/
 Vcs-Git: git://github.com/kaidanim/packaging_deb.git
 Vcs-Browser: https://github.com/kaidanim/packaging_deb/

--- a/debian/control
+++ b/debian/control
@@ -18,15 +18,7 @@ Vcs-Browser: https://github.com/kaidanim/packaging_deb/
 
 Package: kaidan
 Architecture: any
-Depends: libqt5quick5,
-         libqt5quickcontrols2-5,
-         libqt5quickwidgets5,
-         libqt5quickwidgets5,
-         libqt5network5,
-         libqt5gui5,
-         libqt5core5a,
-         libqt5sql5-sqlite,
-         libnotify-bin,
+Depends: libnotify-bin,
          qml-module-qtquick-controls2,
          qml-module-org-kde-kirigami2,
          ${misc:Depends},


### PR DESCRIPTION
The dependency list is autogenerated by debhelper from which libraries the binary is linked against.
It doesn't really make sense to hardcode them, but unfortunately I didn't know that when I did the initial packaging ...